### PR TITLE
Add snippets for Solid components with default exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,26 @@ const ${1:${TM_FILENAME_BASE}}: ParentComponent<{$2}> = (props) => {
 
 </details></td></tr>
       <tr>
+        <td><code>spcompie→</code></td>
+        <td>Solid empty Parent Component. With Imports and default export</td>
+        <td><b>tsx</b></td>
+      </tr>
+      <tr><td colspan="3"><details>
+      <summary><sup>Toggle Code Snippet</sup></summary>
+
+```tsx
+import { ParentComponent } from "solid-js";
+
+const ${1:${TM_FILENAME_BASE}}: ParentComponent<{$2}> = (props) => {
+  $0
+  return <div>{props.children}</div>;
+};
+
+export default ${1:${TM_FILENAME_BASE}};
+```
+
+</details></td></tr>
+      <tr>
         <td><code>sfcompi→</code></td>
         <td>Solid empty Flow Component. With Imports</td>
         <td><b>tsx</b></td>
@@ -198,6 +218,26 @@ const ${1:${TM_FILENAME_BASE}}: FlowComponent<{$2}, ${3:JSX.Element}> = (props) 
 
 </details></td></tr>
       <tr>
+        <td><code>sfcompie→</code></td>
+        <td>Solid empty Flow Component. With Imports and default export</td>
+        <td><b>tsx</b></td>
+      </tr>
+      <tr><td colspan="3"><details>
+      <summary><sup>Toggle Code Snippet</sup></summary>
+
+```tsx
+import { FlowComponent, JSX } from "solid-js";
+
+const ${1:${TM_FILENAME_BASE}}: FlowComponent<{$2}, ${3:JSX.Element}> = (props) => {
+  $0
+  return <div>{props.children}</div>;
+};
+
+export default ${1:${TM_FILENAME_BASE}};
+```
+
+</details></td></tr>
+      <tr>
         <td><code>svcompi→</code></td>
         <td>Solid empty Void Component. With Imports</td>
         <td><b>tsx</b></td>
@@ -212,6 +252,26 @@ const ${1:${TM_FILENAME_BASE}}: VoidComponent<{$2}> = (props) => {
   $0
   return <div></div>;
 };
+```
+
+</details></td></tr>
+      <tr>
+        <td><code>svcompie→</code></td>
+        <td>Solid empty Void Component. With Imports and default export</td>
+        <td><b>tsx</b></td>
+      </tr>
+      <tr><td colspan="3"><details>
+      <summary><sup>Toggle Code Snippet</sup></summary>
+
+```tsx
+import { VoidComponent } from "solid-js";
+
+const ${1:${TM_FILENAME_BASE}}: VoidComponent<{$2}> = (props) => {
+  $0
+  return <div></div>;
+};
+
+export default ${1:${TM_FILENAME_BASE}};
 ```
 
 </details></td></tr>

--- a/snippets/component.tsx.json
+++ b/snippets/component.tsx.json
@@ -77,6 +77,20 @@
     ],
     "description": "Solid empty Parent Component. With Imports"
   },
+  "Solid empty Parent Component. With Imports and default export": {
+    "prefix": "spcompie",
+    "body": [
+      "import { ParentComponent } from \"solid-js\";",
+      "",
+      "const ${1:${TM_FILENAME_BASE}}: ParentComponent<{$2}> = (props) => {",
+      "  $0",
+      "  return <div>{props.children}</div>;",
+      "};",
+      "",
+      "export default ${1:${TM_FILENAME_BASE}};"
+    ],
+    "description": "Solid empty Parent Component. With Imports and default export"
+  },
   "Solid empty Flow Component. With Imports": {
     "prefix": "sfcompi",
     "body": [
@@ -89,6 +103,20 @@
     ],
     "description": "Solid empty Flow Component. With Imports"
   },
+  "Solid empty Flow Component. With Imports and default export": {
+    "prefix": "sfcompie",
+    "body": [
+      "import { FlowComponent, JSX } from \"solid-js\";",
+      "",
+      "const ${1:${TM_FILENAME_BASE}}: FlowComponent<{$2}, ${3:JSX.Element}> = (props) => {",
+      "  $0",
+      "  return <div>{props.children}</div>;",
+      "};",
+      "",
+      "export default ${1:${TM_FILENAME_BASE}};"
+    ],
+    "description": "Solid empty Flow Component. With Imports and default export"
+  },
   "Solid empty Void Component. With Imports": {
     "prefix": "svcompi",
     "body": [
@@ -100,6 +128,20 @@
       "};"
     ],
     "description": "Solid empty Void Component. With Imports"
+  },
+  "Solid empty Void Component. With Imports and default export": {
+    "prefix": "svcompie",
+    "body": [
+      "import { VoidComponent } from \"solid-js\";",
+      "",
+      "const ${1:${TM_FILENAME_BASE}}: VoidComponent<{$2}> = (props) => {",
+      "  $0",
+      "  return <div></div>;",
+      "};",
+      "",
+      "export default ${1:${TM_FILENAME_BASE}};"
+    ],
+    "description": "Solid empty Void Component. With Imports and default export"
   },
   "Component extending an HTML Element": {
     "prefix": "shtmlcomp",


### PR DESCRIPTION
So far there were only snippets with imports and standard exports for `Component`. This pull request also adds this type for `FlowComponent`, `ParentComponent` and `VoidComponent`.